### PR TITLE
[MCP-2] Include lint configuration

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,9 @@
+name: "install uv"
+description: "Install uv using the community action"
+runs:
+  using: "composite"
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: '0.7.2'

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -1,0 +1,21 @@
+name: python lint
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  lock_file:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: uv lock --locked
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: [lock_file]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: uvx ruff check ./src

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv
 .vscode
+.ruff_cache
 __pycache__

--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# Filesystem MCP Server
+
+Python server implementing Model Context Protocol (MCP) for filesystem operations.
+
+## Features
+
+- Read/write files
+- Create/list/delete directories
+- Move files/directories
+- Search files
+- Get file metadata
+
+**Note**: The server will only allow operations within directories specified via `args`.
+
+## API
+
+### Resources
+
+- `file://system`: File system operations interface
+
+### Tools
+
+- **read_file**
+  - Read complete contents of a file
+  - Input: `path` (string)
+  - Reads complete file contents with UTF-8 encoding
+
+- **read_multiple_files**
+  - Read multiple files simultaneously
+  - Input: `paths` (string[])
+  - Failed reads won't stop the entire operation
+
+- **write_file**
+  - Create new file or overwrite existing (exercise caution with this)
+  - Inputs:
+    - `path` (string): File location
+    - `content` (string): File content
+
+- **edit_file**
+  - Make selective edits using advanced pattern matching and formatting
+  - Features:
+    - Line-based and multi-line content matching
+    - Whitespace normalization with indentation preservation
+    - Multiple simultaneous edits with correct positioning
+    - Indentation style detection and preservation
+    - Git-style diff output with context
+    - Preview changes with dry run mode
+  - Inputs:
+    - `path` (string): File to edit
+    - `edits` (array): List of edit operations
+      - `oldText` (string): Text to search for (can be substring)
+      - `newText` (string): Text to replace with
+    - `dryRun` (boolean): Preview changes without applying (default: false)
+  - Returns detailed diff and match information for dry runs, otherwise applies changes
+  - Best Practice: Always use dryRun first to preview changes before applying them
+
+- **create_directory**
+  - Create new directory or ensure it exists
+  - Input: `path` (string)
+  - Creates parent directories if needed
+  - Succeeds silently if directory exists
+
+- **list_directory**
+  - List directory contents with [FILE] or [DIR] prefixes
+  - Input: `path` (string)
+
+- **move_file**
+  - Move or rename files and directories
+  - Inputs:
+    - `source` (string)
+    - `destination` (string)
+  - Fails if destination exists
+
+- **search_files**
+  - Recursively search for files/directories
+  - Inputs:
+    - `path` (string): Starting directory
+    - `pattern` (string): Search pattern
+    - `excludePatterns` (string[]): Exclude any patterns. Glob formats are supported.
+  - Case-insensitive matching
+  - Returns full paths to matches
+
+- **get_file_info**
+  - Get detailed file/directory metadata
+  - Input: `path` (string)
+  - Returns:
+    - Size
+    - Creation time
+    - Modified time
+    - Access time
+    - Type (file/directory)
+    - Permissions
+
+- **list_allowed_directories**
+  - List all directories the server is allowed to access
+  - No input required
+  - Returns:
+    - Directories that this server can read/write from

--- a/makefile
+++ b/makefile
@@ -1,0 +1,2 @@
+lint:
+	ruff check src --fix

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 
+
 from mcp.server.fastmcp import FastMCP
 
 import tools
@@ -9,7 +10,6 @@ from core.types import BaseTool
 
 # Define the MCP server
 server = FastMCP(name="file-reader-server", version="1.0.0")
-
 
 def register_tools():
     tools_list: list[BaseTool]   = [

--- a/src/tools/create_directory.py
+++ b/src/tools/create_directory.py
@@ -32,5 +32,7 @@ class ReadFileTool(BaseTool):
 
     def _entrypoint(self, input: CreateDirectoryinput) -> TextContent:
         os.makedirs(input.path, exist_ok=True)
-        return TextContent(type="text", text=f"Directory created successfully at {input.path}")
-   
+        return TextContent(
+            type="text", 
+            text=f"Directory created successfully at {input.path}",
+        )


### PR DESCRIPTION
This pull request introduces several updates, including the addition of a new GitHub action for setting up `uv`, a Python linting workflow, documentation for a new filesystem MCP server, and minor code formatting improvements. Below is a breakdown of the most important changes:

### CI/CD Enhancements:
* Added a new composite GitHub action in `.github/actions/setup/action.yml` to install `uv` version `0.7.2`. This action will streamline the setup process for `uv` in workflows.
* Introduced a Python linting workflow in `.github/workflows/code-lint.yml` that runs on `push` and `pull_request` events targeting the `main` branch. It includes two jobs:
  - `lock_file`: Ensures dependencies are locked using `uv lock --locked`.
  - [`lint`](diffhunk://#diff-f6abd33739d0188b4f0b161c65f01aac95b036b718aefa65fdd3146b48f8ac15R1-R21): Performs linting on the `src` directory using `ruff`.

### Documentation:
* Added a comprehensive `README.md` detailing the features and API of the new Python-based filesystem MCP server. This includes descriptions of supported operations like file reading, writing, directory management, and file searching.

### Codebase Improvements:
* Added a `lint` target to the `makefile` to run `ruff` with the `--fix` flag, enabling automatic code formatting.
* Made minor formatting adjustments in `src/main.py` and `src/tools/create_directory.py` to improve code readability:
  - Adjusted import spacing in `src/main.py`.
  - Removed unnecessary blank lines and aligned code formatting in `src/main.py` and `src/tools/create_directory.py`. [[1]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L13) [[2]](diffhunk://#diff-97db51019d53bcf354459a85cb69ca70df519aa12a0091dec632cea5a13e1a17L35-R38)